### PR TITLE
ci: fix web build pin and bump Go to 1.26.5

### DIFF
--- a/.github/actions/setup-go-cache/action.yml
+++ b/.github/actions/setup-go-cache/action.yml
@@ -3,9 +3,9 @@ description: "Sets up Go, caches module/cache directories and optionally install
 author: GitHub Copilot
 inputs:
   go-version:
-    description: "Go version to install (e.g. 1.26)"
+    description: "Go version to install (e.g. 1.26.5)"
     required: false
-    default: "1.26"
+    default: "1.26.5"
   install-staticcheck:
     description: "Install staticcheck (true/false)"
     required: false

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Install jaspr CLI
               run: |
-                  dart pub global activate jaspr_cli@0.23.1
+                  dart pub global activate jaspr_cli 0.23.1
 
             - name: Build
               run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/divijg19/physiolink/backend
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020


### PR DESCRIPTION
Fixes failing Backend and Web CI after #56.

- **Web CI**: `dart pub global activate` takes a space-separated version constraint, not `@`; changed `jaspr_cli@0.23.1` to `jaspr_cli 0.23.1`.
- **Backend CI**: `govulncheck` flagged GO-2026-5856 (crypto/tls ECH privacy leak), fixed in go1.26.5. Bumped the `go` directive and the shared setup-go pin to 1.26.5.